### PR TITLE
Fix SynchronizedSet constructor

### DIFF
--- a/src/Iesi.Collections.Test/Generic/SynchronizedSetFixture.cs
+++ b/src/Iesi.Collections.Test/Generic/SynchronizedSetFixture.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Iesi.Collections.Generic;
+using NUnit.Framework;
+#if !NETCOREAPP1_0
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
+namespace Iesi.Collections.Test.Generic
+{
+    /// <summary>
+    /// Summary description for ReadOnlySetFixture.
+    /// </summary>
+    [TestFixture]
+    public class SynchronizedSetFixture : GenericSetFixture
+    {
+        protected override ISet<string> CreateInstance()
+        {
+            return new SynchronizedSet<string>(new HashSet<string>());
+        }
+
+        protected override ISet<string> CreateInstance(ICollection<string> init)
+        {
+            return new SynchronizedSet<string>(new HashSet<string>(init));
+        }
+
+        protected override Type ExpectedType
+        {
+            get { return typeof(SynchronizedSet<string>); }
+        }
+
+#if !NETCOREAPP1_0
+		[Test(Description = "ES-1")]
+		public void ShouldBeAbleToDeserializeBinarySerialized()
+		{
+			var set = new SynchronizedSet<int>(new HashSet<int> { 1, 10, 5 });
+
+			var formatter = new BinaryFormatter();
+			using (var stream = new MemoryStream())
+			{
+				formatter.Serialize(stream, set);
+
+				stream.Position = 0;
+				var deserialized = (SynchronizedSet<int>)formatter.Deserialize(stream);
+				Assert.That(set, Is.EquivalentTo(deserialized));
+			}
+		}
+#endif
+
+    }
+}

--- a/src/Iesi.Collections.Test/Generic/SynchronizedSetFixture.cs
+++ b/src/Iesi.Collections.Test/Generic/SynchronizedSetFixture.cs
@@ -6,25 +6,26 @@ using NUnit.Framework;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
+
 namespace Iesi.Collections.Test.Generic
 {
-    /// <summary>
-    /// Summary description for ReadOnlySetFixture.
-    /// </summary>
-    [TestFixture]
-    public class SynchronizedSetFixture : GenericSetFixture
-    {
-        protected override ISet<string> CreateInstance()
-        {
-            return new SynchronizedSet<string>(new HashSet<string>());
-        }
+	/// <summary>
+	/// Summary description for ReadOnlySetFixture.
+	/// </summary>
+	[TestFixture]
+	public class SynchronizedSetFixture : GenericSetFixture
+	{
+		protected override ISet<string> CreateInstance()
+		{
+			return new SynchronizedSet<string>(new HashSet<string>());
+		}
 
-        protected override ISet<string> CreateInstance(ICollection<string> init)
-        {
-            return new SynchronizedSet<string>(new HashSet<string>(init));
-        }
+		protected override ISet<string> CreateInstance(ICollection<string> init)
+		{
+			return new SynchronizedSet<string>(new HashSet<string>(init));
+		}
 
-        protected override Type ExpectedType => typeof(SynchronizedSet<string>);
+		protected override Type ExpectedType => typeof(SynchronizedSet<string>);
 
 #if !NETCOREAPP1_0
 		[Test(Description = "ES-1")]
@@ -44,5 +45,5 @@ namespace Iesi.Collections.Test.Generic
 		}
 #endif
 
-    }
+	}
 }

--- a/src/Iesi.Collections.Test/Generic/SynchronizedSetFixture.cs
+++ b/src/Iesi.Collections.Test/Generic/SynchronizedSetFixture.cs
@@ -24,10 +24,7 @@ namespace Iesi.Collections.Test.Generic
             return new SynchronizedSet<string>(new HashSet<string>(init));
         }
 
-        protected override Type ExpectedType
-        {
-            get { return typeof(SynchronizedSet<string>); }
-        }
+        protected override Type ExpectedType => typeof(SynchronizedSet<string>);
 
 #if !NETCOREAPP1_0
 		[Test(Description = "ES-1")]

--- a/src/Iesi.Collections/Generic/LinkedHashSet.cs
+++ b/src/Iesi.Collections/Generic/LinkedHashSet.cs
@@ -20,7 +20,7 @@ namespace Iesi.Collections.Generic
 		, IReadOnlyCollection<T>
 #endif
 	{
-		private readonly Dictionary<T, LinkedHashNode<T>> _elements;
+		private readonly Dictionary<T, LinkedHashNode<T>> _elements = new Dictionary<T, LinkedHashNode<T>>();
 		private LinkedHashNode<T> _first, _last;
 
 		/// <summary>
@@ -28,7 +28,6 @@ namespace Iesi.Collections.Generic
 		/// </summary>
 		public LinkedHashSet()
 		{
-			_elements = new Dictionary<T, LinkedHashNode<T>>();
 		}
 
 
@@ -37,8 +36,8 @@ namespace Iesi.Collections.Generic
 		/// </summary>
 		/// <param name="initialValues"></param>
 		public LinkedHashSet(IEnumerable<T> initialValues)
-			: this()
 		{
+			if (initialValues == null) throw new ArgumentNullException(nameof(initialValues));
 			UnionWith(initialValues);
 		}
 

--- a/src/Iesi.Collections/Generic/LinkedHashSet.cs
+++ b/src/Iesi.Collections/Generic/LinkedHashSet.cs
@@ -37,7 +37,6 @@ namespace Iesi.Collections.Generic
 		/// <param name="initialValues"></param>
 		public LinkedHashSet(IEnumerable<T> initialValues)
 		{
-			if (initialValues == null) throw new ArgumentNullException(nameof(initialValues));
 			UnionWith(initialValues);
 		}
 
@@ -174,6 +173,7 @@ namespace Iesi.Collections.Generic
 		/// <param name="other">The collection to compare to the current set.</param><exception cref="T:System.ArgumentNullException"><paramref name="other"/> is null.</exception>
 		public void UnionWith(IEnumerable<T> other)
 		{
+			if (other == null) throw new ArgumentNullException(nameof(other));
 			foreach (var item in other)
 				Add(item);
 		}

--- a/src/Iesi.Collections/Generic/ReadOnlySet.cs
+++ b/src/Iesi.Collections/Generic/ReadOnlySet.cs
@@ -29,7 +29,7 @@ namespace Iesi.Collections.Generic
 		/// <param name="basisSet">The <c>Set</c> that is wrapped.</param>
 		public ReadOnlySet(ISet<T> basisSet)
 		{
-			_basisSet = basisSet;
+			_basisSet = basisSet ?? throw new ArgumentNullException(nameof(basisSet));
 		}
 
 

--- a/src/Iesi.Collections/Generic/SynchronizedSet.cs
+++ b/src/Iesi.Collections/Generic/SynchronizedSet.cs
@@ -29,8 +29,8 @@ namespace Iesi.Collections.Generic
 		/// <param name="basisSet">The <c>Set</c> object that this object will wrap.</param>
 		public SynchronizedSet(ISet<T> basisSet)
 		{
-			_basisSet = basisSet;
-			_syncRoot = ((ICollection)basisSet).SyncRoot;
+			_basisSet = basisSet ?? throw new ArgumentNullException(nameof(basisSet));
+			_syncRoot = basisSet is ICollection c ? c.SyncRoot : new object();
 			if (_syncRoot == null)
 				throw new ArgumentException("The set you specified returned a null SyncRoot.");
 		}
@@ -294,7 +294,8 @@ namespace Iesi.Collections.Generic
 		/// <filterpriority>1</filterpriority>
 		public IEnumerator<T> GetEnumerator()
 		{
-			return _basisSet.GetEnumerator();
+			lock (_syncRoot)
+				return _basisSet.GetEnumerator();
 		}
 
 		#endregion

--- a/src/Iesi.Collections/Generic/SynchronizedSet.cs
+++ b/src/Iesi.Collections/Generic/SynchronizedSet.cs
@@ -30,7 +30,7 @@ namespace Iesi.Collections.Generic
 		public SynchronizedSet(ISet<T> basisSet)
 		{
 			_basisSet = basisSet ?? throw new ArgumentNullException(nameof(basisSet));
-			_syncRoot = basisSet is ICollection c ? c.SyncRoot : new object();
+			_syncRoot = basisSet is ICollection c ? c.SyncRoot : this;
 			if (_syncRoot == null)
 				throw new ArgumentException("The set you specified returned a null SyncRoot.");
 		}


### PR DESCRIPTION
None of the sets in the BCL actually implement ICollection, so constructor
was throwing an exception.